### PR TITLE
Fix docker build image unknown tag name for tag version

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -55,7 +55,10 @@ runs:
       shell: bash
       id: determine_tag_name
       run: |
-        if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+        if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
+          tag_name=`echo $GITHUB_REF | sed -e 's:^refs/tags/::'`
+          primary_tag="${tag_name}"
+        elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
           primary_tag="latest"
         elif [ "${{ github.event_name }}" = "pull_request" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -55,14 +55,14 @@ runs:
       shell: bash
       id: determine_tag_name
       run: |
-        if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          tag_name=`echo $GITHUB_REF | sed -e 's:^refs/tags/::'`
-          primary_tag="${tag_name}"
-        elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
+        if [ "$GITHUB_REF" = "refs/heads/main" ]; then
           primary_tag="latest"
         elif [ "${{ github.event_name }}" = "pull_request" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
           primary_tag="pr-${pr_num}"
+        elif [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
+          tag_name=`echo $GITHUB_REF | sed -e 's:^refs/tags/::'`
+          primary_tag="${tag_name}"
         else
           primary_tag="unknown"
         fi

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -60,9 +60,11 @@ runs:
         elif [ "${{ github.event_name }}" = "pull_request" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
           primary_tag="pr-${pr_num}"
+        elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
+          primary_tag="pr-${pr_num}"
         elif [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          tag_name=`echo $GITHUB_REF | sed -e 's:^refs/tags/::'`
-          primary_tag="${tag_name}"
+          primary_tag="${{ github.ref_name }}"
         else
           primary_tag="unknown"
         fi

--- a/.github/workflows/dockers-tensorflow-ingress-filter-image.yml
+++ b/.github/workflows/dockers-tensorflow-ingress-filter-image.yml
@@ -45,12 +45,52 @@ on:
       - "Makefile"
       - "requirements.txt"
       - "VALD_TENSORFLOW_INGRESS_FILTER_VERSION"
+  pull_request_target:
+    paths:
+      - ".github/actions/docker-build/action.yaml"
+      - ".github/workflows/dockers-tensorflow-ingress-filter-image.yml"
+      - ".github/workflows/update-version.yml"
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - "main.py"
+      - "Makefile"
+      - "requirements.txt"
+      - "VALD_TENSORFLOW_INGRESS_FILTER_VERSION"
 
 jobs:
+  dump_contexts_to_log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(github) }}
+      - name: Dump job context
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(job) }}
+      - name: Dump steps context
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(steps) }}
+      - name: Dump runner context
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(runner) }}
+      - name: Dump strategy context
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(strategy) }}
+      - name: Dump matrix context
+        run: echo $JSON
+        env:
+          JSON: ${{ toJSON(matrix) }}
   build:
     strategy:
       max-parallel: 4
     runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event.pull_request.head.repo.fork == true && github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci/approved')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith( github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup QEMU


### PR DESCRIPTION
This PR fixes the docker build tag name "unknown" for tag release due to the missing tag release handling like here.
https://github.com/vdaas/vald/blob/main/.github/actions/docker-build/action.yaml#L67-L87

In this PR I also added missing `pull_request_target` event handling for PR release.


For reviewers:
- Since `pull_request_target` event always triggered on main branch action, the changes of this event from this PR will not be effective until the PR is merged.
  - Ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 
  ```
  This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. 
  ```