### PR TITLE
Fix image tag for pull request events

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -33,9 +33,6 @@ outputs:
   IMAGE_NAME:
     description: "image name"
     value: ${{ steps.image_name.outputs.IMAGE_NAME }}
-  ALTER_IMAGE_NAME:
-    description: "alter image name"
-    value: ${{ steps.image_name.outputs.ALTER_IMAGE_NAME }}
   PRIMARY_TAG:
     description: "primary tag"
     value: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
@@ -53,12 +50,8 @@ runs:
       id: image_name
       run: |
         image_name=`make docker/name/${TARGET}`
-        alter_org=`make docker/name/org/alter`
-        alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
         echo "IMAGE_NAME is: ${image_name}"
-        echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
         echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
-        echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
       env:
         TARGET: ${{ inputs.target }}
     - name: Determine tag name
@@ -111,16 +104,14 @@ runs:
       shell: bash
       id: add_extra_tags
       run: |
-        extra_tags="-t ${ALTER_IMAGE_NAME}:${PRIMARY_TAG}"
+        extra_tags=""
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          latest_tags="-t ${IMAGE_NAME}:latest -t ${ALTER_IMAGE_NAME}:latest"
-          extra_tags="${extra_tags} ${latest_tags}"
+          extra_tags="-t ${IMAGE_NAME}:latest"
         fi
         echo "EXTRA_TAGS is determined: ${extra_tags}"
         echo "EXTRA_TAGS=${extra_tags}" >> $GITHUB_OUTPUT
       env:
         IMAGE_NAME: ${{ steps.image_name.outputs.IMAGE_NAME }}
-        ALTER_IMAGE_NAME: ${{ steps.image_name.outputs.ALTER_IMAGE_NAME }}
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Build and Push
       shell: bash

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -33,12 +33,18 @@ outputs:
   IMAGE_NAME:
     description: "image name"
     value: ${{ steps.image_name.outputs.IMAGE_NAME }}
+  ALTER_IMAGE_NAME:
+    description: "alter image name"
+    value: ${{ steps.image_name.outputs.ALTER_IMAGE_NAME }}
   PRIMARY_TAG:
     description: "primary tag"
     value: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
   PLATFORMS:
     description: "target platforms"
     value: ${{ steps.determine_platforms.outputs.PLATFORMS }}
+  EXTRA_TAGS:
+    description: "extra tags"
+    value: ${{ steps.add_extra_tags.outputs.EXTRA_TAGS }}
 runs:
   using: "composite"
   steps:
@@ -47,8 +53,12 @@ runs:
       id: image_name
       run: |
         image_name=`make docker/name/${TARGET}`
+        alter_org=`make docker/name/org/alter`
+        alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
         echo "IMAGE_NAME is: ${image_name}"
+        echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
         echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
+        echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
       env:
         TARGET: ${{ inputs.target }}
     - name: Determine tag name
@@ -60,15 +70,19 @@ runs:
         echo "GITHUB_EVENT_NAME ${{ github.event_name }}"
         echo "GITHUB_EVENT_NUMBER  ${{ github.event.number }}"
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          primary_tag="${{ github.ref_name }}"
+          tag_name=`echo $GITHUB_REF | sed -e 's:^refs/tags/::'`
+          primary_tag="${tag_name}"
         elif [ "${{ github.event_name }}" = "pull_request" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
+          echo "PR-${pr_num}" > VALD_TENSORFLOW_INGRESS_FILTER_VERSION
           primary_tag="pr-${pr_num}"
         elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
+          echo "PR-${pr_num}" > VALD_TENSORFLOW_INGRESS_FILTER_VERSION
           primary_tag="pr-${pr_num}"
         elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
-          primary_tag="latest"
+          echo "nightly" > VALD_TENSORFLOW_INGRESS_FILTER_VERSION
+          primary_tag="nightly"
         else
           primary_tag="unknown"
         fi
@@ -81,6 +95,8 @@ runs:
         if [ "${TARGET_PLATFORMS}" = "" ]; then
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             platforms="linux/amd64"
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            platforms="linux/amd64"
           else
             platforms=`make docker/platforms`
           fi
@@ -91,17 +107,21 @@ runs:
         echo "PLATFORMS=${platforms}" >> $GITHUB_OUTPUT
       env:
         TARGET_PLATFORMS: ${{ inputs.platforms }}
-    - name: Add version tag
+    - name: Add extra tags
       shell: bash
-      id: add_version_tag
+      id: add_extra_tags
       run: |
-        if [ "$GITHUB_REF" = "refs/tags/.*" ]; then
-          extra_tags="-t `make docker/name/tag/version`"
-        else
-          extra_tags=""
+        extra_tags="-t ${ALTER_IMAGE_NAME}:${PRIMARY_TAG}"
+        if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
+          latest_tags="-t ${IMAGE_NAME}:latest -t ${ALTER_IMAGE_NAME}:latest"
+          extra_tags="${extra_tags} ${latest_tags}"
         fi
         echo "EXTRA_TAGS is determined: ${extra_tags}"
         echo "EXTRA_TAGS=${extra_tags}" >> $GITHUB_OUTPUT
+      env:
+        IMAGE_NAME: ${{ steps.image_name.outputs.IMAGE_NAME }}
+        ALTER_IMAGE_NAME: ${{ steps.image_name.outputs.ALTER_IMAGE_NAME }}
+        PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Build and Push
       shell: bash
       id: build_and_push
@@ -117,4 +137,5 @@ runs:
         PLATFORMS: ${{ steps.determine_platforms.outputs.PLATFORMS }}
         BUILDER: ${{ inputs.builder }}
         LABEL_OPTS: "--label org.opencontainers.image.url=${{ github.event.repository.html_url }} --label org.opencontainers.image.source=${{ github.event.repository.html_url }} --label org.opencontainers.image.revision=${{ github.sha }}"
+        EXTRA_TAGS: ${{ steps.add_extra_tags.outputs.EXTRA_TAGS }}
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -55,16 +55,20 @@ runs:
       shell: bash
       id: determine_tag_name
       run: |
-        if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-          primary_tag="latest"
+        echo "GITHUB_REF $GITHUB_REF"
+        echo "GITHUB_EVENT_PATH $GITHUB_EVENT_PATH"
+        echo "GITHUB_EVENT_NAME ${{ github.event_name }}"
+        echo "GITHUB_EVENT_NUMBER  ${{ github.event.number }}"
+        if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
+          primary_tag="${{ github.ref_name }}"
         elif [ "${{ github.event_name }}" = "pull_request" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
           primary_tag="pr-${pr_num}"
         elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
           primary_tag="pr-${pr_num}"
-        elif [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          primary_tag="${{ github.ref_name }}"
+        elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
+          primary_tag="latest"
         else
           primary_tag="unknown"
         fi


### PR DESCRIPTION
This PR fixes the tag version `latest` will be uploaded to the DockerHub when the event is `pull_request` or `pull_request_target`.
The correct version should be the pull request number version. (`pr-xxx`).

